### PR TITLE
Use https for requests to storage account

### DIFF
--- a/src/main/java/quickstart/Quickstart.java
+++ b/src/main/java/quickstart/Quickstart.java
@@ -156,7 +156,7 @@ public class Quickstart {
             // Create a ServiceURL to call the Blob service. We will also use this to construct the ContainerURL
             SharedKeyCredentials creds = new SharedKeyCredentials(accountName, accountKey);
             // We are using a default pipeline here, you can learn more about it at https://github.com/Azure/azure-storage-java/wiki/Azure-Storage-Java-V10-Overview
-            final ServiceURL serviceURL = new ServiceURL(new URL("http://" + accountName + ".blob.core.windows.net"), StorageURL.createPipeline(creds, new PipelineOptions()));
+            final ServiceURL serviceURL = new ServiceURL(new URL("https://" + accountName + ".blob.core.windows.net"), StorageURL.createPipeline(creds, new PipelineOptions()));
 
             // Let's create a container using a blocking call to Azure Storage
             // If container exists, we'll catch and continue


### PR DESCRIPTION
When I attempted to run this project after setting the credentials in the environment variables, I ran into this error - 
`Service error returned: 400
`

On further investigation, I determined that the underlying cause is - 
```
Service error returned: com.microsoft.azure.storage.blob.models.StorageErrorException: Status code 400, "<?xml version="1.0" encoding="utf-8"?><Error><Code>AccountRequiresHttps</Code><Message>The account being accessed does not support http.
```


When we attempt to create a storage account, it seems like the default is "Enabled" for the "Secure transfer required" option. Changing to https to fix this