### PR TITLE
Fix maven dependency issues

### DIFF
--- a/v12/pom.xml
+++ b/v12/pom.xml
@@ -4,13 +4,6 @@
   <groupId>Azure-Storage-SDK-V10-Java</groupId>
   <artifactId>QuickStart</artifactId>
   <version>0.1</version>
-  <repositories>
-    <repository>
-      <id>commicrosoftazure-2334</id>
-      <name>commicrosoftazure-2334</name>
-      <url>https://oss.sonatype.org/content/repositories/commicrosoftazure-2334</url>
-    </repository>
-  </repositories>
 
   <build>
     <plugins>

--- a/v12/pom.xml
+++ b/v12/pom.xml
@@ -25,7 +25,7 @@
           <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
       </plugin>
-      
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -34,7 +34,7 @@
           <mainClass>quickstart.Quickstart</mainClass>
         </configuration>
       </plugin>
-      
+
     </plugins>
   </build>
 
@@ -42,12 +42,12 @@
     <dependency>
      <groupId>com.azure</groupId>
      <artifactId>azure-storage-common</artifactId>
-     <version>12.0.0</version>
+     <version>12.13.0</version>
    </dependency>
     <dependency>
      <groupId>com.azure</groupId>
      <artifactId>azure-storage-blob</artifactId>
-     <version>12.0.0</version>
+     <version>12.14.0</version>
    </dependency>
   </dependencies>
 </project>

--- a/v12/pom.xml
+++ b/v12/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>Azure-Storage-SDK-V10-Java</groupId>
   <artifactId>QuickStart</artifactId>
@@ -40,14 +41,14 @@
 
   <dependencies>
     <dependency>
-     <groupId>com.azure</groupId>
-     <artifactId>azure-storage-common</artifactId>
-     <version>12.13.0</version>
-   </dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-storage-common</artifactId>
+      <version>12.13.0</version>
+    </dependency>
     <dependency>
-     <groupId>com.azure</groupId>
-     <artifactId>azure-storage-blob</artifactId>
-     <version>12.14.0</version>
-   </dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-storage-blob</artifactId>
+      <version>12.14.0</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
# Changes

Fix problems building the v12 example, caused by a missing pom.xml in the 12.0.0 version. The fix uses newer version of the artifacts, which provide their pom files.

I have provided all changes as individual commits, to allow using them all, or make cherry picks instead.

This relates to https://github.com/Azure-Samples/azure-sdk-for-java-storage-blob-upload-download/issues/15